### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,7 +154,7 @@ GoSquared.prototype.track = function(track) {
  * @param {Track} track
  */
 
-GoSquared.prototype.completedOrder = function(track) {
+GoSquared.prototype.orderCompleted = function(track) {
   var products = track.products();
   var items = [];
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -248,7 +248,7 @@ describe('GoSquared', function() {
       });
 
       it('should send a transaction', function() {
-        analytics.track('completed order', {
+        analytics.track('order completed', {
           id: 'a9173991',
           total: 90,
           quantity: 10,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
